### PR TITLE
Update to Xamarin.Mac for 64-bit support

### DIFF
--- a/Source/Pablo Desktop.sln
+++ b/Source/Pablo Desktop.sln
@@ -11,8 +11,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PabloDraw", "PabloDraw\Pabl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Nat", "..\Libraries\Mono.Nat\src\Mono.Nat\Mono.Nat.csproj", "{F5D74163-145F-47BF-83DC-D0E07249C6CA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PabloDraw.Mac", "PabloDraw.Mac\PabloDraw.Mac.csproj", "{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PabloDraw.Console", "PabloDraw.Console\PabloDraw.Console.csproj", "{0457895A-719B-47E9-84F3-356B2A1F8D3C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Eto", "Eto", "{C8B59D00-6086-492E-9112-3DA8E5025FBB}"
@@ -29,8 +27,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.WinForms - net45", "..\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Wpf - net45", "..\Libraries\Eto\Source\Eto.Wpf\Eto.Wpf - net45.csproj", "{63137FA0-CA55-11E3-9C1A-0800200C9A66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.XamMac - net45", "..\Libraries\Eto\Source\Eto.Mac\Eto.XamMac - net45.csproj", "{BF405A10-C9EB-11E3-9C1A-0800200C9A66}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{88CCB819-8E11-429C-94D7-D5A27A671129}"
 	ProjectSection(SolutionItems) = preProject
 		Pablo Desktop.sln = Pablo Desktop.sln
@@ -40,6 +36,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lidgren.Network", "..\Libraries\lidgren\Lidgren.Network\Lidgren.Network.csproj", "{49BA1C69-6104-41AC-A5D8-B54FA9F696E8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.XamMac2 - net45", "..\Libraries\Eto\Source\Eto.Mac\Eto.XamMac2 - net45.csproj", "{856E8C70-2702-11E4-8C21-0800200C9A66}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PabloDraw.Mac", "PabloDraw.Mac\PabloDraw.Mac.csproj", "{5590729F-3176-4A91-94E3-54F75DA2EB9D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Mac - net45", "..\Libraries\Eto\Source\Eto.Mac\Eto.Mac - net45.csproj", "{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -99,16 +99,6 @@ Global
 		{F5D74163-145F-47BF-83DC-D0E07249C6CA}.Win Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5D74163-145F-47BF-83DC-D0E07249C6CA}.Win Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5D74163-145F-47BF-83DC-D0E07249C6CA}.Win Release|Any CPU.Build.0 = Release|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Mac App Store|Any CPU.ActiveCfg = Release-MAS|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Mac App Store|Any CPU.Build.0 = Release-MAS|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Mac Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Mac Debug|Any CPU.Build.0 = Debug|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Mac Developer|Any CPU.ActiveCfg = Release|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Mac Developer|Any CPU.Build.0 = Release|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Mac Release|Any CPU.ActiveCfg = Release|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Mac Release|Any CPU.Build.0 = Release|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Win Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}.Win Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0457895A-719B-47E9-84F3-356B2A1F8D3C}.Mac App Store|Any CPU.ActiveCfg = Release|Any CPU
 		{0457895A-719B-47E9-84F3-356B2A1F8D3C}.Mac App Store|Any CPU.Build.0 = Release|Any CPU
 		{0457895A-719B-47E9-84F3-356B2A1F8D3C}.Mac Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -193,16 +183,6 @@ Global
 		{63137FA0-CA55-11E3-9C1A-0800200C9A66}.Win Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63137FA0-CA55-11E3-9C1A-0800200C9A66}.Win Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63137FA0-CA55-11E3-9C1A-0800200C9A66}.Win Release|Any CPU.Build.0 = Release|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Mac App Store|Any CPU.ActiveCfg = Release|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Mac App Store|Any CPU.Build.0 = Release|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Mac Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Mac Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Mac Developer|Any CPU.ActiveCfg = Release|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Mac Developer|Any CPU.Build.0 = Release|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Mac Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Mac Release|Any CPU.Build.0 = Release|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Win Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66}.Win Release|Any CPU.ActiveCfg = Release|Any CPU
 		{49BA1C69-6104-41AC-A5D8-B54FA9F696E8}.Mac App Store|Any CPU.ActiveCfg = Release|Any CPU
 		{49BA1C69-6104-41AC-A5D8-B54FA9F696E8}.Mac App Store|Any CPU.Build.0 = Release|Any CPU
 		{49BA1C69-6104-41AC-A5D8-B54FA9F696E8}.Mac Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -225,6 +205,28 @@ Global
 		{856E8C70-2702-11E4-8C21-0800200C9A66}.Mac Release|Any CPU.Build.0 = Release|Any CPU
 		{856E8C70-2702-11E4-8C21-0800200C9A66}.Win Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{856E8C70-2702-11E4-8C21-0800200C9A66}.Win Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Mac App Store|Any CPU.ActiveCfg = Release|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Mac App Store|Any CPU.Build.0 = Release|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Mac Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Mac Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Mac Developer|Any CPU.ActiveCfg = Release|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Mac Developer|Any CPU.Build.0 = Release|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Mac Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Mac Release|Any CPU.Build.0 = Release|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Win Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5590729F-3176-4A91-94E3-54F75DA2EB9D}.Win Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Mac App Store|Any CPU.ActiveCfg = Release|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Mac App Store|Any CPU.Build.0 = Release|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Mac Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Mac Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Mac Developer|Any CPU.ActiveCfg = Release|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Mac Developer|Any CPU.Build.0 = Release|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Mac Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Mac Release|Any CPU.Build.0 = Release|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Win Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Win Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Win Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}.Win Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -236,8 +238,8 @@ Global
 		{543B2F90-CA56-11E3-9C1A-0800200C9A66} = {C8B59D00-6086-492E-9112-3DA8E5025FBB}
 		{9F51798A-354C-47A1-9207-4BB7D7FC7FC4} = {C8B59D00-6086-492E-9112-3DA8E5025FBB}
 		{63137FA0-CA55-11E3-9C1A-0800200C9A66} = {C8B59D00-6086-492E-9112-3DA8E5025FBB}
-		{BF405A10-C9EB-11E3-9C1A-0800200C9A66} = {C8B59D00-6086-492E-9112-3DA8E5025FBB}
 		{856E8C70-2702-11E4-8C21-0800200C9A66} = {C8B59D00-6086-492E-9112-3DA8E5025FBB}
+		{3E7995E0-C9EB-11E3-9C1A-0800200C9A66} = {C8B59D00-6086-492E-9112-3DA8E5025FBB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8F8DD3BA-3F1A-4B83-87FD-07C1D69CB86C}

--- a/Source/PabloDraw.Console/PabloDraw.Console.csproj
+++ b/Source/PabloDraw.Console/PabloDraw.Console.csproj
@@ -40,15 +40,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <CustomCommands>
-      <CustomCommands>
-        <Command>
-          <type>BeforeBuild</type>
-          <command>./copyassemblies.sh ${ProjectConfigName} ${ProjectDir}/Assemblies</command>
-          <workingdir>${ProjectDir}</workingdir>
-        </Command>
-      </CustomCommands>
-    </CustomCommands>
     <Commandlineparameters>--convert /Users/curtis/Downloads/mirage/VD-FLIP.ans --out /Users/curtis/Downloads/mirage/VD-FLIP.txt</Commandlineparameters>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
@@ -60,19 +51,6 @@
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
     <Commandlineparameters>--platform mac --server --adminpw hello</Commandlineparameters>
-    <CustomCommands>
-      <CustomCommands>
-        <Command>
-          <type>BeforeBuild</type>
-          <command>./copyassemblies.sh ${ProjectConfigName} ${ProjectDir}/Assemblies</command>
-          <workingdir>${ProjectDir}</workingdir>
-        </Command>
-        <Command>
-          <type>AfterBuild</type>
-          <command>cp ${TargetFile} /Users/curtis/Projects/Pablo/Pablo.Gallery/src/Pablo.Gallery/Util/PabloDraw.Console.exe</command>
-        </Command>
-      </CustomCommands>
-    </CustomCommands>
     <DebugType>none</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
@@ -130,6 +108,18 @@
       <Project>{35DBE6BB-B46D-4AE9-8156-FBFC6EC2BB69}</Project>
       <Name>Pablo</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Libraries\Eto\Source\Eto.Gtk\Eto.Gtk2 - net45.csproj">
+      <Project>{80915A80-CA54-11E3-9C1A-0800200C9A66}</Project>
+      <Name>Eto.Gtk2 - net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Libraries\Eto\Source\Eto.WinForms\Eto.WinForms - net45.csproj">
+      <Project>{9F51798A-354C-47A1-9207-4BB7D7FC7FC4}</Project>
+      <Name>Eto.WinForms - net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Libraries\Eto\Source\Eto.Mac\Eto.Mac - net45.csproj">
+      <Project>{3E7995E0-C9EB-11E3-9C1A-0800200C9A66}</Project>
+      <Name>Eto.Mac - net45</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/PabloDraw.Mac/AppDelegate.cs
+++ b/Source/PabloDraw.Mac/AppDelegate.cs
@@ -1,8 +1,8 @@
-using System;
+﻿using System;
 using Eto.Forms;
 using Pablo.Interface;
 
-#if __Unified__
+#if __UNIFIED__
 using AppKit;
 using ObjCRuntime;
 using Foundation;

--- a/Source/PabloDraw.Mac/Assets.xcassets/Contents.json
+++ b/Source/PabloDraw.Mac/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+﻿{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Source/PabloDraw.Mac/PabloDraw.Mac.csproj
+++ b/Source/PabloDraw.Mac/PabloDraw.Mac.csproj
@@ -3,217 +3,102 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{90B2D03E-7B1D-4C1F-8ADB-664F980C2A32}</ProjectGuid>
-    <ProjectTypeGuids>{42C0BBD9-55CE-4FC1-8D90-A7348ABAFB23};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{5590729F-3176-4A91-94E3-54F75DA2EB9D}</ProjectGuid>
+    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
     <RootNamespace>PabloDraw</RootNamespace>
     <AssemblyName>PabloDraw</AssemblyName>
-    <ReleaseVersion>
-    </ReleaseVersion>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <ReleaseVersion></ReleaseVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>True</DebugSymbols>
+    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>False</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;MAC</DefineConstants>
+    <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>False</ConsolePause>
-    <CustomCommands>
-      <CustomCommands>
-        <Command>
-          <type>Custom</type>
-          <name>Deploy</name>
-          <command>../macbuild ${ProjectConfig}</command>
-          <workingdir>${SolutionDir}</workingdir>
-          <pauseExternalConsole>True</pauseExternalConsole>
-        </Command>
-        <Command>
-          <type>Custom</type>
-          <name>AOT</name>
-          <command>mono --aot ${TargetDir}/PabloDraw.app/Contents/MonoBundle/*.{exe,dll}</command>
-        </Command>
-      </CustomCommands>
-    </CustomCommands>
-    <EnableCodeSigning>False</EnableCodeSigning>
-    <CodeSigningKey>Mac Developer</CodeSigningKey>
-    <CreatePackage>False</CreatePackage>
-    <EnablePackageSigning>False</EnablePackageSigning>
-    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-    <IncludeMonoRuntime>false</IncludeMonoRuntime>
-    <CodeSignEntitlements>PabloDraw-entitlements.plist</CodeSignEntitlements>
-    <MonoBundlingExtraArgs>-linkskip System</MonoBundlingExtraArgs>
-    <UseSGen>false</UseSGen>
-    <LinkMode>SdkOnly</LinkMode>
-    <UseRefCounting>false</UseRefCounting>
-    <I18n>rare,west</I18n>
-    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>True</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>False</ConsolePause>
-    <DefineConstants>MAC</DefineConstants>
-    <CustomCommands>
-      <CustomCommands>
-        <Command>
-          <type>Custom</type>
-          <name>Deploy</name>
-          <command>../macbuild ${ProjectConfig}</command>
-          <workingdir>${SolutionDir}</workingdir>
-          <pauseExternalConsole>True</pauseExternalConsole>
-        </Command>
-      </CustomCommands>
-    </CustomCommands>
     <EnableCodeSigning>false</EnableCodeSigning>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
     <CreatePackage>false</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
-    <IncludeMonoRuntime>true</IncludeMonoRuntime>
-    <CodeSigningKey>3rd Party Mac Developer Application</CodeSigningKey>
-    <PackageSigningKey>Developer ID Installer</PackageSigningKey>
-    <CodeSignEntitlements>Entitlements.plist</CodeSignEntitlements>
+    <IncludeMonoRuntime>false</IncludeMonoRuntime>
     <UseSGen>true</UseSGen>
-    <I18n>rare,west</I18n>
-    <MonoBundlingExtraArgs>--linkskip=Pablo --linkskip=Newtonsoft.Json</MonoBundlingExtraArgs>
-    <UseRefCounting>false</UseRefCounting>
-    <LinkMode>Full</LinkMode>
+    <UseRefCounting>true</UseRefCounting>
     <HttpClientHandler>HttpClientHandler</HttpClientHandler>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-MAS|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>True</Optimize>
-    <OutputPath>bin\Release-MAS</OutputPath>
-    <DefineConstants>MAC</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <IncludeMonoRuntime>True</IncludeMonoRuntime>
-    <UseSGen>True</UseSGen>
+    <LinkMode>None</LinkMode>
+    <XamMacArch>x86_64</XamMacArch>
+    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
     <I18n>other,rare,west</I18n>
-    <ConsolePause>False</ConsolePause>
-    <EnableCodeSigning>false</EnableCodeSigning>
-    <CreatePackage>True</CreatePackage>
-    <CustomCommands>
-      <CustomCommands>
-        <Command>
-          <type>Custom</type>
-          <name>Deploy</name>
-          <command>../macbuild ${ProjectConfig}</command>
-          <workingdir>${SolutionDir}</workingdir>
-        </Command>
-      </CustomCommands>
-    </CustomCommands>
-    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-    <EnablePackageSigning>false</EnablePackageSigning>
-    <LinkMode>SdkOnly</LinkMode>
-    <DebugSymbols>true</DebugSymbols>
-    <UseRefCounting>false</UseRefCounting>
-    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <EnableSGenConc>true</EnableSGenConc>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-Developer|AnyCPU' ">
-    <DebugType>none</DebugType>
-    <Optimize>True</Optimize>
-    <OutputPath>bin\Release-Developer</OutputPath>
-    <DefineConstants>MAC</DefineConstants>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <DefineConstants></DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IncludeMonoRuntime>True</IncludeMonoRuntime>
-    <UseSGen>True</UseSGen>
-    <LinkMode>Full</LinkMode>
-    <CodeSignEntitlements>Entitlements.plist</CodeSignEntitlements>
-    <I18n>rare,west</I18n>
-    <ConsolePause>False</ConsolePause>
-    <EnableCodeSigning>False</EnableCodeSigning>
-    <CodeSigningKey>Developer ID Application: Curtis Wensley</CodeSigningKey>
-    <CreatePackage>False</CreatePackage>
-    <CustomCommands>
-      <CustomCommands>
-        <Command>
-          <type>Custom</type>
-          <name>Deploy</name>
-          <command>../macbuild ${ProjectConfig}</command>
-          <workingdir>${SolutionDir}</workingdir>
-        </Command>
-        <Command>
-          <type>AfterBuild</type>
-          <command>cp -Rf ${TargetDir}/PabloDraw.app ${SolutionDir}/Releases/3.1</command>
-        </Command>
-      </CustomCommands>
-    </CustomCommands>
-    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
+    <EnableCodeSigning>false</EnableCodeSigning>
+    <CreatePackage>true</CreatePackage>
     <EnablePackageSigning>false</EnablePackageSigning>
-    <UseRefCounting>false</UseRefCounting>
-    <MonoBundlingExtraArgs>--linkskip=Pablo</MonoBundlingExtraArgs>
+    <IncludeMonoRuntime>true</IncludeMonoRuntime>
+    <UseSGen>true</UseSGen>
+    <UseRefCounting>true</UseRefCounting>
+    <LinkMode>SdkOnly</LinkMode>
     <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <XamMacArch>x86_64</XamMacArch>
+    <CodeSigningKey>Mac Developer</CodeSigningKey>
+    <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
+    <I18n>other,rare,west</I18n>
+    <EnableSGenConc>true</EnableSGenConc>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpCompress">
-      <HintPath>..\packages\sharpcompress.0.10.1.3\lib\net40\SharpCompress.dll</HintPath>
-    </Reference>
-    <Reference Include="XamMac, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065" />
+    <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Startup.cs" />
-    <Compile Include="..\GlobalAssemblyInfo.cs">
-      <Link>GlobalAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="AppDelegate.cs" />
+    <ImageAsset Include="Assets.xcassets\Contents.json" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
     <None Include="Entitlements.plist" />
-    <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Mono\MonoMac\v0.0\Mono.MonoMac.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\Pablo.Interface\Pablo.Interface.csproj">
-      <Project>{3FAACC7E-D156-4599-B0D1-6177AD78E8B1}</Project>
-      <Name>Pablo.Interface</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Pablo\Pablo.csproj">
-      <Project>{35DBE6BB-B46D-4AE9-8156-FBFC6EC2BB69}</Project>
-      <Name>Pablo</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Libraries\lidgren\Lidgren.Network\Lidgren.Network.csproj">
-      <Project>{49BA1C69-6104-41AC-A5D8-B54FA9F696E8}</Project>
-      <Name>Lidgren.Network</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Libraries\Mono.Nat\src\Mono.Nat\Mono.Nat.csproj">
-      <Project>{F5D74163-145F-47BF-83DC-D0E07249C6CA}</Project>
-      <Name>Mono.Nat</Name>
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="Startup.cs" />
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Libraries\Eto\Source\Eto.Mac\Eto.XamMac2 - net45.csproj">
+      <Project>{856E8C70-2702-11E4-8C21-0800200C9A66}</Project>
+      <Name>Eto.XamMac2 - net45</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Libraries\Eto\Source\Eto\Eto - pcl.csproj">
       <Project>{35EF0A4E-2A1A-492C-8BED-106774EA09F2}</Project>
       <Name>Eto - pcl</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Libraries\Eto\Source\Eto.Mac\Eto.XamMac - net45.csproj">
-      <Project>{BF405A10-C9EB-11E3-9C1A-0800200C9A66}</Project>
-      <Name>Eto.XamMac - net45</Name>
+    <ProjectReference Include="..\Pablo\Pablo.csproj">
+      <Project>{35DBE6BB-B46D-4AE9-8156-FBFC6EC2BB69}</Project>
+      <Name>Pablo</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Pablo.Interface\Pablo.Interface.csproj">
+      <Project>{3FAACC7E-D156-4599-B0D1-6177AD78E8B1}</Project>
+      <Name>Pablo.Interface</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="PabloDraw.icns" />
     <Content Include="PabloDraw-Document.icns" />
   </ItemGroup>
-  <ProjectExtensions>
-    <MonoDevelop>
-      <Properties>
-        <Deployment.LinuxDeployData generateScript="False" scriptName="pablodraw" />
-      </Properties>
-    </MonoDevelop>
-  </ProjectExtensions>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
 </Project>

--- a/Source/PabloDraw.Mac/Startup.cs
+++ b/Source/PabloDraw.Mac/Startup.cs
@@ -8,7 +8,7 @@ using System;
 using System.Runtime.InteropServices;
 using Eto.Mac.Forms.ToolBar;
 
-#if __Unified__
+#if __UNIFIED__
 using AppKit;
 using ObjCRuntime;
 using Foundation;

--- a/Source/PabloDraw.Mac/packages.config
+++ b/Source/PabloDraw.Mac/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" requireReinstallation="true" />
-  <package id="sharpcompress" version="0.10.1.3" targetFramework="net40" />
-</packages>


### PR DESCRIPTION
- Use newer Xamarin.Mac vs XamMac to provide 64-bit support on macOS
- Fix build for windows under CI