### PR TITLE
Fix loading animated documents from the command line

### DIFF
--- a/Source/Pablo.Interface/Main.cs
+++ b/Source/Pablo.Interface/Main.cs
@@ -805,7 +805,8 @@ namespace Pablo.Interface
 				/**
 				var bufferedStream = new MemoryStream();
 				stream.WriteTo(bufferedStream);
-				stream.Close ();
+				stream.Close();
+				bufferedStream.Position = 0;
 				/**/
 				var bufferedStream = new BufferedStream(stream, 20 * 1024);
 
@@ -840,7 +841,7 @@ namespace Pablo.Interface
 		{
 			if (loadingStream != null)
 			{
-				// loadingStream.Dispose();
+				loadingStream.Dispose();
 				loadingStream = null;
 				PabloApplication.Instance.Invoke(delegate
 				{
@@ -869,10 +870,9 @@ namespace Pablo.Interface
 
 			if (File.Exists(fileName))
 			{
-				using (var stream = File.OpenRead(fileName))
-				{
-					return LoadFile(fileName, stream, null, editMode ?? EditMode, setFileList, hasSavePermissions);
-				}
+				// do not dispose, we may need to load in the background for animated documents.
+				var stream = File.OpenRead(fileName);
+				return LoadFile(fileName, stream, null, editMode ?? EditMode, setFileList, hasSavePermissions);
 			}
 			return false;
 		}

--- a/Source/Pablo/Document.cs
+++ b/Source/Pablo/Document.cs
@@ -102,7 +102,7 @@ namespace Pablo
 		public virtual void Load(string fileName, Format format, Handler handler)
 		{
 			this.FileName = fileName;
-			var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read); // can't dispose here if we load in background!
+			var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read); // can't dispose here if we load in background!
 			Load(stream, format, handler);
 		}
 

--- a/Source/Pablo/Formats/Animated/AnimatedDocument.cs
+++ b/Source/Pablo/Formats/Animated/AnimatedDocument.cs
@@ -151,8 +151,8 @@ namespace Pablo.Formats.Animated
 							{
 								if (bs != null)
 									bs.Close();
-								if (stream != null)
-									stream.Close();
+								// if (stream != null)
+								// 	stream.Close();
 								bs = null;
 								stream = null;
 							}

--- a/Source/Pablo/Formats/Animated/BaudStream.cs
+++ b/Source/Pablo/Formats/Animated/BaudStream.cs
@@ -26,21 +26,12 @@ namespace Pablo.Formats.Animated
 				TickWait = (value > 0) ? (long)(((TimeSpan.TicksPerSecond * 1.2) / (value / 8))) : 0;
 			}
 		}
-		
-		public override bool CanRead
-		{
-			get { return true; }
-		}
 
-		public override bool CanSeek
-		{
-			get { return false; }
-		}
+		public override bool CanRead => stream.CanRead;
 
-		public override bool CanWrite
-		{
-			get { return false; }
-		}
+		public override bool CanSeek => stream.CanSeek;
+
+		public override bool CanWrite => false;
 		
 		public long TickWait
 		{

--- a/Source/Pablo/Formats/Rip/FormatRip.cs
+++ b/Source/Pablo/Formats/Rip/FormatRip.cs
@@ -47,12 +47,12 @@ namespace Pablo.Formats.Rip
 			 */
 			if (document.AnimateView && Application.Instance != null) {
 				document.BGI.DelayDraw = true; // for faster animation
-				Application.Instance.Invoke (delegate {
-					//lastEnableZoom = handler.EnableZoom;
-#if DESKTOP
-					//handler.EnableZoom = false;
-#endif
-				});
+// 				Application.Instance.Invoke (delegate {
+// 					//lastEnableZoom = handler.EnableZoom;
+// #if DESKTOP
+// 					//handler.EnableZoom = false;
+// #endif
+// 				});
 			}			
 		  
 			try {

--- a/Source/Pablo/Sauce/SauceStream.cs
+++ b/Source/Pablo/Sauce/SauceStream.cs
@@ -22,20 +22,11 @@ namespace Pablo.Sauce
 			}
 			else Sauce = null;
 		}
-		public override bool CanRead
-		{
-			get { return true; }
-		}
+		public override bool CanRead => stream.CanRead;
 
-		public override bool CanSeek
-		{
-			get { return true; }
-		}
+		public override bool CanSeek => stream.CanSeek;
 
-		public override bool CanWrite
-		{
-			get { return false; }
-		}
+		public override bool CanWrite => false;
 
 		public override void Flush() { stream.Flush(); }
 

--- a/Source/PabloDraw/CommandHandlers/ConvertCommandLine.cs
+++ b/Source/PabloDraw/CommandHandlers/ConvertCommandLine.cs
@@ -111,8 +111,9 @@ namespace PabloDraw.CommandHandlers
 			sw2.Stop ();
 			args.Writer.WriteLine ("Convertion rate: {0}, total seconds: {1}", iters / sw2.Elapsed.TotalSeconds, sw2.Elapsed.TotalSeconds);
 			/**/
-			if (!Directory.Exists(Path.GetDirectoryName(outFile)))
-				Directory.CreateDirectory(Path.GetDirectoryName(outFile));
+			var outDir = Path.GetDirectoryName(outFile);
+			if (!string.IsNullOrEmpty(outDir) && !Directory.Exists(outDir))
+				Directory.CreateDirectory(outDir);
 
 			using (var destinationStream = new FileStream(outFile, FileMode.Create, FileAccess.Write))
 			{


### PR DESCRIPTION
- Only dispose of the loading stream after the document is loaded as it can be used during animation
- Ensure CanSeek/CanRead are propagated for BaudStream and SauceStream
- Don't try to create the out directory if the out file does not contain a path when converting
Fixes #57