### PR TITLE
Windows: Fix selecting character

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
                 "program": "${workspaceFolder}/artifacts/bin/PabloDraw/${config:var.BuildConfiguration}/net6.0/PabloDraw.app/Contents/MacOS/PabloDraw",
             },
             "windows": {
-                "program": "${workspaceFolder}/artifacts/bin/PabloDraw/${config:var.BuildConfiguration}/net6.0-windows/PabloDraw.dll",
+                "program": "${workspaceFolder}/artifacts/bin/PabloDraw/${config:var.BuildConfiguration}/net6.0-windows/win-x64/PabloDraw.dll",
             },
             "linux": {
                 "program": "${workspaceFolder}/artifacts/bin/PabloDraw/${config:var.BuildConfiguration}/net6.0/linux-x64/PabloDraw.dll",

--- a/Source/Pablo/Formats/Character/Controls/CharacterSelectPad.cs
+++ b/Source/Pablo/Formats/Character/Controls/CharacterSelectPad.cs
@@ -62,7 +62,7 @@ namespace Pablo.Formats.Character.Controls
 				ReadOnly = true,
 				Bordered = true
 			};
-			preview.MouseDown += (sender, e) =>
+			preview.MouseUp += (sender, e) =>
 			{
 				SelectCharacter();
 				e.Handled = true;


### PR DESCRIPTION
This fixes the issue where the dialog would show after clicking anywhere else.

Fixes #60