### PR TITLE
Fix release builds on Mac

### DIFF
--- a/Source/PabloDraw/PabloDraw.csproj
+++ b/Source/PabloDraw/PabloDraw.csproj
@@ -39,8 +39,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(BuildTarget) == 'Mac' and $(Configuration) == 'Release'">
     <EnableDmgBuild>True</EnableDmgBuild>
-    <TrimMode>Link</TrimMode>
+    <TrimMode>partial</TrimMode>
     <PublishTrimmed>True</PublishTrimmed>
+    <TrimmerRemoveSymbols>true</TrimmerRemoveSymbols>
     <DmgName>PabloDraw-Mac</DmgName>
     <DmgVolumeName>PabloDraw</DmgVolumeName>
     <DmgOutputPath>$(PublishDir)</DmgOutputPath> <!-- Eto will use this by default if specified in 2.7.2 -->


### PR DESCRIPTION
We only want to trim system assemblies, which is now "partial" vs. "link".  This caused 3.3.0-beta3 to crash on startup.